### PR TITLE
Add where info to report

### DIFF
--- a/gspan_mining/config.py
+++ b/gspan_mining/config.py
@@ -39,6 +39,13 @@ parser.add_argument(
          'default inf'
 )
 parser.add_argument(
+    '-mm', '--max_mining',
+    type=int,
+    default=float('inf'),
+    help='int, upper bound for the number of generated subgraphs, '
+         'default inf'
+)
+parser.add_argument(
     '-d', '--directed',
     type=str2bool,
     default=False,

--- a/gspan_mining/config.py
+++ b/gspan_mining/config.py
@@ -39,13 +39,6 @@ parser.add_argument(
          'default inf'
 )
 parser.add_argument(
-    '-mm', '--max_mining',
-    type=int,
-    default=float('inf'),
-    help='int, upper bound for the number of generated subgraphs, '
-         'default inf'
-)
-parser.add_argument(
     '-d', '--directed',
     type=str2bool,
     default=False,

--- a/gspan_mining/gspan.py
+++ b/gspan_mining/gspan.py
@@ -352,7 +352,6 @@ class gSpan(object):
         if self._where:
             print('where: {}'.format(list(set([p.gid for p in projected]))))
         print('\n-----------------\n')
-        
 
     def _get_forward_root_edges(self, g, frm):
         result = []

--- a/gspan_mining/gspan.py
+++ b/gspan_mining/gspan.py
@@ -348,6 +348,9 @@ class gSpan(object):
         if self._where:
             print('where: {}'.format(list(set([p.gid for p in projected]))))
         print('\n-----------------\n')
+        # abort if we mined to many subgraphs
+        if len(self._frequent_subgraphs) >= self._max_ngraphs:
+            return
 
     def _get_forward_root_edges(self, g, frm):
         result = []

--- a/gspan_mining/gspan.py
+++ b/gspan_mining/gspan.py
@@ -191,8 +191,7 @@ class gSpan(object):
                  is_undirected=True,
                  verbose=False,
                  visualize=False,
-                 where=False,
-                 max_mining=float('inf')):
+                 where=False):
         """Initialize gSpan instance."""
         self._database_file_name = database_file_name
         self.graphs = dict()
@@ -201,7 +200,6 @@ class gSpan(object):
         self._min_support = min_support
         self._min_num_vertices = min_num_vertices
         self._max_num_vertices = max_num_vertices
-        self._max_mining = max_mining
         self._DFScode = DFScode()
         self._support = 0
         self._frequent_size1_subgraphs = list()
@@ -512,9 +510,6 @@ class gSpan(object):
         return res
 
     def _subgraph_mining(self, projected):
-        # abort if we mined to many subgraphs
-        if len(self._frequent_subgraphs) >= self._max_mining:
-            return self
         self._support = self._get_support(projected)
         if self._support < self._min_support:
             return

--- a/gspan_mining/gspan.py
+++ b/gspan_mining/gspan.py
@@ -335,13 +335,17 @@ class gSpan(object):
         print('\nSupport: {}'.format(self._support))
 
         # Add some report info to pandas dataframe "self._report_df".
+        _data = {
+            'support': [self._support],
+            'description': [display_str],
+            'num_vert': self._DFScode.get_num_vertices()
+        }
+        if self._where: # if where is set to true add the isomorph graphs to the report data
+            _data['isomorph_graphs'] = [list(set([p.gid for p in projected]))]
+        
         self._report_df = self._report_df.append(
             pd.DataFrame(
-                {
-                    'support': [self._support],
-                    'description': [display_str],
-                    'num_vert': self._DFScode.get_num_vertices()
-                },
+                _data,
                 index=[int(repr(self._counter)[6:-1])]
             )
         )

--- a/gspan_mining/gspan.py
+++ b/gspan_mining/gspan.py
@@ -191,7 +191,8 @@ class gSpan(object):
                  is_undirected=True,
                  verbose=False,
                  visualize=False,
-                 where=False):
+                 where=False,
+                 max_mining=float('inf')):
         """Initialize gSpan instance."""
         self._database_file_name = database_file_name
         self.graphs = dict()
@@ -200,6 +201,7 @@ class gSpan(object):
         self._min_support = min_support
         self._min_num_vertices = min_num_vertices
         self._max_num_vertices = max_num_vertices
+        self._max_mining = max_mining
         self._DFScode = DFScode()
         self._support = 0
         self._frequent_size1_subgraphs = list()
@@ -348,9 +350,7 @@ class gSpan(object):
         if self._where:
             print('where: {}'.format(list(set([p.gid for p in projected]))))
         print('\n-----------------\n')
-        # abort if we mined to many subgraphs
-        if len(self._frequent_subgraphs) >= self._max_ngraphs:
-            return
+        
 
     def _get_forward_root_edges(self, g, frm):
         result = []
@@ -508,6 +508,9 @@ class gSpan(object):
         return res
 
     def _subgraph_mining(self, projected):
+        # abort if we mined to many subgraphs
+        if len(self._frequent_subgraphs) >= self._max_mining:
+            return self
         self._support = self._get_support(projected)
         if self._support < self._min_support:
             return

--- a/gspan_mining/main.py
+++ b/gspan_mining/main.py
@@ -13,7 +13,6 @@ from .gspan import gSpan
 
 def main(FLAGS=None):
     """Run gSpan."""
-
     if FLAGS is None:
         FLAGS, _ = parser.parse_known_args(args=sys.argv[1:])
 
@@ -30,7 +29,8 @@ def main(FLAGS=None):
         is_undirected=(not FLAGS.directed),
         verbose=FLAGS.verbose,
         visualize=FLAGS.plot,
-        where=FLAGS.where
+        where=FLAGS.where,
+        max_mining=FLAGS.max_mining,
     )
 
     gs.run()

--- a/gspan_mining/main.py
+++ b/gspan_mining/main.py
@@ -29,7 +29,7 @@ def main(FLAGS=None):
         is_undirected=(not FLAGS.directed),
         verbose=FLAGS.verbose,
         visualize=FLAGS.plot,
-        where=FLAGS.where,
+        where=FLAGS.where
     )
 
     gs.run()

--- a/gspan_mining/main.py
+++ b/gspan_mining/main.py
@@ -30,7 +30,6 @@ def main(FLAGS=None):
         verbose=FLAGS.verbose,
         visualize=FLAGS.plot,
         where=FLAGS.where,
-        max_mining=FLAGS.max_mining,
     )
 
     gs.run()


### PR DESCRIPTION
## Modification
Adding `isomorph_graphs` to the report frame.

## Use Case
Some applications in graph mining require to perform subgraph-isomorphism-tests between the generated features and the graphs in the dataset. The accelerate the process, we can use the __where__ from the report. To access it form the report object it self we would add it to report data. 