### PR TITLE
Small fix for obsolete pandas append method

### DIFF
--- a/gspan_mining/gspan.py
+++ b/gspan_mining/gspan.py
@@ -333,7 +333,7 @@ class gSpan(object):
         print('\nSupport: {}'.format(self._support))
 
         # Add some report info to pandas dataframe "self._report_df".
-        self._report_df = self._report_df.append(
+        self._report_df = pd.concat([self._report_df,
             pd.DataFrame(
                 {
                     'support': [self._support],
@@ -341,7 +341,7 @@ class gSpan(object):
                     'num_vert': self._DFScode.get_num_vertices()
                 },
                 index=[int(repr(self._counter)[6:-1])]
-            )
+            )]
         )
         if self._visualize:
             g.plot()


### PR DESCRIPTION
Added a small fix to replace the obsolete pandas .append method with the new pd.concat method.

The non existent method throws the following error:

```
File "/gSpan/gspan_mining/main.py", line 36, in main
    gs.run()
  File "/gSpan/gspan_mining/gspan.py", line 24, in deco
    func(self)
  File "/gSpan/gspan_mining/gspan.py", line 315, in run
    self._subgraph_mining(projected)
  File "/gSpan/gspan_mining/gspan.py", line 523, in _subgraph_mining
    self._report(projected)
  File "/gSpan/gspan_mining/gspan.py", line 346, in _report
    self._report_df = self._report_df.append(
  File "/env/lib/python3.10/site-packages/pandas/core/generic.py", line 6204, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'append'. Did you mean: '_append'?
```

* Tested the new code works using: 
```
python -m gspan_mining -s 5000 ./graphdata/graph.data
```
