### PR TITLE
change append to use the new dataframe syntax because deprecation

### DIFF
--- a/gspan_mining/graph.py
+++ b/gspan_mining/graph.py
@@ -126,15 +126,14 @@ class Graph(object):
                     print('e {} {} {}'.format(frm, to, edges[to].elb))
                     display_str += 'e {} {} {}'.format(frm, to, edges[to].elb)
         return display_str
-
-    def plot(self):
-        """Visualize the graph."""
+    
+    def as_nx_graph(self):
         try:
-            import networkx as nx
-            import matplotlib.pyplot as plt
+            import networkx as nx        
         except Exception as e:
-            print('Can not plot graph: {}'.format(e))
+            print('Can not transform to networkx graph: {}'.format(e))
             return
+        
         gnx = nx.Graph() if self.is_undirected else nx.DiGraph()
         vlbs = {vid: v.vlb for vid, v in self.vertices.items()}
         elbs = {}
@@ -143,8 +142,23 @@ class Graph(object):
         for vid, v in self.vertices.items():
             for to, e in v.edges.items():
                 if (not self.is_undirected) or vid < to:
-                    gnx.add_edge(vid, to, label=e.elb)
+                    gnx.add_edge(vid, to, d=e.elb)
                     elbs[(vid, to)] = e.elb
+
+        return gnx, vlbs, elbs
+
+
+    def plot(self):
+        """Visualize the graph."""
+        try:
+            import networkx as nx   
+            import matplotlib.pyplot as plt
+        except Exception as e:
+            print('Can not plot graph: {}'.format(e))
+            return
+        
+        gnx, vlbs, elbs = self.as_nx_graph()
+
         fsize = (min(16, 1 * len(self.vertices)),
                  min(16, 1 * len(self.vertices)))
         plt.figure(3, figsize=fsize)

--- a/gspan_mining/gspan.py
+++ b/gspan_mining/gspan.py
@@ -332,9 +332,7 @@ class gSpan(object):
         display_str = g.display()
         print('\nSupport: {}'.format(self._support))
 
-        # Add some report info to pandas dataframe "self._report_df".
-        self._report_df = self._report_df.append(
-            pd.DataFrame(
+        newframe = pd.DataFrame(
                 {
                     'support': [self._support],
                     'description': [display_str],
@@ -342,7 +340,9 @@ class gSpan(object):
                 },
                 index=[int(repr(self._counter)[6:-1])]
             )
-        )
+
+        # Add some report info to pandas dataframe "self._report_df".
+        pd.concat([self._report_df, newframe])
         if self._visualize:
             g.plot()
         if self._where:


### PR DESCRIPTION
closes #29 

Pandas deprecated the append method, now we use the concat syntax as described in https://pandas.pydata.org/pandas-docs/version/1.5/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append